### PR TITLE
Adds an 'image overlay' feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ optional arguments:
                         add crop marks (default: True)
   --faces {all,front,back}
                         which faces to print (default: all)
+  --overlay OVERLAY     image file to overlay on every card
 ```
 
 ### convert

--- a/print.py
+++ b/print.py
@@ -60,6 +60,12 @@ if __name__ == "__main__":
         choices=["all", "front", "back"],
         default="all",
     )
+    parser.add_argument(
+        "--overlay", 
+        help="image file to overlay on every card",
+        type=str,
+        default=None,
+    )
     args = parser.parse_args()
 
     # Parse decklist
@@ -84,6 +90,7 @@ if __name__ == "__main__":
             border_crop=args.border_crop,
             background_color=background_color,
             cropmarks=args.cropmarks,
+            overlay=args.overlay,
         )
     else:
         print_cards_matplotlib(
@@ -94,4 +101,5 @@ if __name__ == "__main__":
             dpi=args.dpi,
             border_crop=args.border_crop,
             background_color=args.background,
+            overlay=args.overlay,
         )


### PR DESCRIPTION
This adds an `--overlay` argument to specify a file path. That image is then overlaid on top of each card image as they're plotted to the result png or pdf.

For example: With [this overlay](https://github.com/DiddiZ/mtg-proxies/assets/602691/230724e4-0920-4832-8f12-9987175223b2), the resulting image may look something like:

![image](https://github.com/DiddiZ/mtg-proxies/assets/602691/ff79d80c-86ca-4472-9835-02aba12cefd1)


I added this for my own use, but figured someone else might find it useful.