### PR TITLE
add language option

### DIFF
--- a/mtgproxies/decklists/sanitizing.py
+++ b/mtgproxies/decklists/sanitizing.py
@@ -63,8 +63,10 @@ def get_print_warnings(card) -> list[str]:
         warnings.append("low resolution scan")
     if card["collector_number"][-1] in ["p", "s"]:
         warnings.append("promo")
-    if card["lang"] != "en":
+    if scryfall.get_language() is None and card["lang"] != "en":
         warnings.append("non-english print")
+    if scryfall.get_language() is not None and card["lang"] != scryfall.get_language():
+        warnings.append("non-" + scryfall.get_language() + " print")
     if card["border_color"] != "black":
         warnings.append(card["border_color"] + " border")
     return warnings

--- a/print.py
+++ b/print.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from mtgproxies import fetch_scans_scryfall, print_cards_fpdf, print_cards_matplotlib
 from mtgproxies.cli import parse_decklist_spec
+from scryfall.scryfall import use_database, use_language
 
 
 def papersize(string: str) -> np.ndarray:
@@ -60,7 +61,19 @@ if __name__ == "__main__":
         choices=["all", "front", "back"],
         default="all",
     )
+    parser.add_argument(
+        '--language',
+        help='language of the cards',
+        type=str,
+        default=None,
+        choices=["en", "es", "fr", "de", "it", "pt", "ja", "ko", "ru", "zhs", "zht", "he", "la", "grc", "ar", "sa", "ph"],
+    )
     args = parser.parse_args()
+
+    # Switch database and language if language is set
+    if args.language is not None:
+        use_database('all_cards')
+        use_language(args.language)
 
     # Parse decklist
     decklist = parse_decklist_spec(args.decklist)

--- a/scryfall/__init__.py
+++ b/scryfall/__init__.py
@@ -6,6 +6,7 @@ from scryfall.scryfall import (
     get_cards,
     get_faces,
     get_image,
+    get_language,
     get_price,
     oracle_ids_by_name,
     recommend_print,


### PR DESCRIPTION
Added `--language` option to allow non-English language proxies to output.
The input file format will remain English, but only the output cards will have the specified language enabled.

Since the difference would be large if I did a bucket relay of parameters or replaced all calls to get_cards, I implemented it in scryfall.py in the form of holding it in a global variable.
I am not very familiar with python and there may be a better way.